### PR TITLE
constraint cmdliner version

### DIFF
--- a/opam
+++ b/opam
@@ -9,7 +9,7 @@ tags: [ "unicode" "text" "utf-8" "utf-16" "codec" "org:erratique" ]
 license: "BSD3"
 available: [ ocaml-version >= "4.00.0"]
 depends: ["ocamlfind"]
-depopts: ["cmdliner"
+depopts: ["cmdliner" { >= "0.9.6" }
           "cmdliner" {test} ]
 build:
 [


### PR DESCRIPTION
uutf fails to build with cmdliner's versions prior to 0.9.6, as it relies on `Arg.doc_alts_enum`
